### PR TITLE
feat: add TX writeStream with loopback buffer and standalone test suite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,3 +49,13 @@ SOAPY_SDR_MODULE_UTIL(
         ${ATOMIC_LIBS}
         ${OTHER_LIBS}
 )
+
+# --- Tests ---
+enable_testing()
+add_executable(test_loopback test/test_loopback.cpp)
+target_link_libraries(test_loopback PRIVATE SoapySDR)
+target_compile_definitions(test_loopback PRIVATE
+    SOAPY_LOOPBACK_MODULE_PATH="$<TARGET_FILE:soapyloopback>")
+add_dependencies(test_loopback soapyloopback)
+add_test(NAME test_loopback COMMAND test_loopback)
+set_tests_properties(test_loopback PROPERTIES TIMEOUT 30)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.10)
 project(SoapyLoopback CXX)
 
 find_package(SoapySDR "0.8.0" NO_MODULE REQUIRED)

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -44,11 +44,26 @@ SoapyLoopback::SoapyLoopback(const SoapySDR::Kwargs &args):
     gainMode(false),
     offsetMode(false),
     digitalAGC(false),
+    biasTee(false),
     ticks(false),
     bufferedElems(0),
     resetBuffer(false),
     gainMin(0.0),
-    gainMax(0.0)
+    gainMax(0.0),
+    // Stream setup tracking
+    _rxStreamSetup(false),
+    _txStreamSetup(false),
+    // TX/loopback state
+    _txActive(false),
+    _txBufferLength(DEFAULT_BUFFER_LENGTH),
+    _txNumBuffers(DEFAULT_NUM_BUFFERS),
+    _loopbackFormat(""),
+    _loopbackBytesPerSample(8),  // Default to CF32, will be set in setupStream
+    _loopback_head(0),
+    _loopback_tail(0),
+    _loopback_count(0),
+    _loopback_overflow(false),
+    _loopbackEnabled(false)
 {
 
 }
@@ -96,7 +111,7 @@ size_t SoapyLoopback::getNumChannels(const int dir) const
 
 bool SoapyLoopback::getFullDuplex(const int direction, const size_t channel) const
 {
-    return false;
+    return true;  // Support simultaneous TX and RX for loopback testing
 }
 
 /*******************************************************************
@@ -113,10 +128,7 @@ std::vector<std::string> SoapyLoopback::listAntennas(const int direction, const 
 
 void SoapyLoopback::setAntenna(const int direction, const size_t channel, const std::string &name)
 {
-    if (direction != SOAPY_SDR_RX)
-    {
-        throw std::runtime_error("setAntena failed: RTL-SDR only supports RX");
-    }
+    // Accept any antenna setting for both RX and TX
 }
 
 std::string SoapyLoopback::getAntenna(const int direction, const size_t channel) const

--- a/SoapyLoopback.hpp
+++ b/SoapyLoopback.hpp
@@ -40,6 +40,10 @@
 class SoapyLoopback: public SoapySDR::Device
 {
 public:
+    // Sentinel pointers to distinguish RX vs TX streams
+    static SoapySDR::Stream* const kRxStream;
+    static SoapySDR::Stream* const kTxStream;
+
     SoapyLoopback(const SoapySDR::Kwargs &args);
 
     ~SoapyLoopback(void);
@@ -93,6 +97,14 @@ public:
             const size_t numElems,
             int &flags,
             long long &timeNs,
+            const long timeoutUs = 100000);
+
+    int writeStream(
+            SoapySDR::Stream *stream,
+            const void * const *buffs,
+            const size_t numElems,
+            int &flags,
+            const long long timeNs = 0,
             const long timeoutUs = 100000);
 
     /*******************************************************************
@@ -306,4 +318,27 @@ public:
     std::atomic<bool> resetBuffer;
 
     double gainMin, gainMax;
+
+    // Stream setup tracking
+    bool _rxStreamSetup;
+    bool _txStreamSetup;
+
+    // TX state
+    bool _txActive;
+    size_t _txBufferLength;
+    size_t _txNumBuffers;
+
+    // Loopback format tracking
+    std::string _loopbackFormat;  // Store the format for loopback operations
+    size_t _loopbackBytesPerSample;  // Bytes per sample for the loopback format
+
+    // Loopback ring buffer (TX writes here, RX reads from here)
+    std::mutex _loopback_mutex;
+    std::condition_variable _loopback_cond;
+    std::vector<Buffer> _loopback_buffs;
+    size_t _loopback_head;
+    size_t _loopback_tail;
+    std::atomic<size_t> _loopback_count;
+    std::atomic<bool> _loopback_overflow;
+    bool _loopbackEnabled;  // when true, RX reads from loopback buffer instead of synthetic data
 };

--- a/Streaming.cpp
+++ b/Streaming.cpp
@@ -31,6 +31,10 @@
 #include <climits> //SHRT_MAX
 #include <cstring> // memcpy
 
+// Define sentinel stream pointers (C++11 compatible)
+SoapySDR::Stream* const SoapyLoopback::kRxStream = reinterpret_cast<SoapySDR::Stream*>(static_cast<uintptr_t>(1));
+SoapySDR::Stream* const SoapyLoopback::kTxStream = reinterpret_cast<SoapySDR::Stream*>(static_cast<uintptr_t>(2));
+
 
 std::vector<std::string> SoapyLoopback::getStreamFormats(const int direction, const size_t channel) const {
     std::vector<std::string> formats;
@@ -147,34 +151,49 @@ SoapySDR::Stream *SoapyLoopback::setupStream(
         throw std::runtime_error("setupStream invalid channel selection");
     }
 
-    //check the format
+    //check the format and determine bytes per sample
+    size_t bytesPerSample = 0;
     if (format == SOAPY_SDR_CF32)
     {
         SoapySDR_log(SOAPY_SDR_INFO, "Using format CF32.");
-        //rxFormat = RTL_RX_FORMAT_FLOAT32;
-    }
-    else if (format == SOAPY_SDR_CS12)
-    {
-        SoapySDR_log(SOAPY_SDR_INFO, "Using format CS12.");
-        //rxFormat = RTL_RX_FORMAT_INT16;
+        bytesPerSample = 8;  // 2 * sizeof(float)
     }
     else if (format == SOAPY_SDR_CS16)
     {
         SoapySDR_log(SOAPY_SDR_INFO, "Using format CS16.");
-        //rxFormat = RTL_RX_FORMAT_INT16;
+        bytesPerSample = 4;  // 2 * sizeof(int16_t)
+    }
+    else if (format == SOAPY_SDR_CS12)
+    {
+        SoapySDR_log(SOAPY_SDR_INFO, "Using format CS12.");
+        bytesPerSample = 3;  // packed 12-bit I/Q
     }
     else if (format == SOAPY_SDR_CS8) {
         SoapySDR_log(SOAPY_SDR_INFO, "Using format CS8.");
-        //rxFormat = RTL_RX_FORMAT_INT8;
+        bytesPerSample = 2;  // 2 * sizeof(int8_t)
     }
     else
     {
         throw std::runtime_error(
                 "setupStream invalid format '" + format
-                        + "' -- Only CS8, CS16 and CF32 are supported by SoapyLoopback module.");
+                        + "' -- Only CS8, CS12, CS16 and CF32 are supported by SoapyLoopback module.");
     }
 
-    bufferLength = DEFAULT_BUFFER_LENGTH;
+    // Store format for loopback operations (first stream setup wins)
+    if (_loopbackFormat.empty())
+    {
+        _loopbackFormat = format;
+        _loopbackBytesPerSample = bytesPerSample;
+        SoapySDR_logf(SOAPY_SDR_DEBUG, "Loopback format set to %s (%zu bytes/sample)", format.c_str(), bytesPerSample);
+    }
+    else if (_loopbackFormat != format)
+    {
+        SoapySDR_logf(SOAPY_SDR_WARNING, "Loopback: TX and RX using different formats (%s vs %s). Using %s for loopback.",
+            _loopbackFormat.c_str(), format.c_str(), _loopbackFormat.c_str());
+    }
+
+    // Parse buffer configuration
+    size_t localBufferLength = DEFAULT_BUFFER_LENGTH;
     if (args.count("bufflen") != 0)
     {
         try
@@ -182,14 +201,13 @@ SoapySDR::Stream *SoapyLoopback::setupStream(
             int bufferLength_in = std::stoi(args.at("bufflen"));
             if (bufferLength_in > 0)
             {
-                bufferLength = bufferLength_in;
+                localBufferLength = bufferLength_in;
             }
         }
         catch (const std::invalid_argument &){}
     }
-    SoapySDR_logf(SOAPY_SDR_DEBUG, "RTL-SDR Using buffer length %d", bufferLength);
 
-    numBuffers = DEFAULT_NUM_BUFFERS;
+    size_t localNumBuffers = DEFAULT_NUM_BUFFERS;
     if (args.count("buffers") != 0)
     {
         try
@@ -197,62 +215,106 @@ SoapySDR::Stream *SoapyLoopback::setupStream(
             int numBuffers_in = std::stoi(args.at("buffers"));
             if (numBuffers_in > 0)
             {
-                numBuffers = numBuffers_in;
+                localNumBuffers = numBuffers_in;
             }
         }
         catch (const std::invalid_argument &){}
     }
-    SoapySDR_logf(SOAPY_SDR_DEBUG, "RTL-SDR Using %d buffers", numBuffers);
 
-    asyncBuffs = 0;
-    if (args.count("asyncBuffs") != 0)
+    SoapySDR_logf(SOAPY_SDR_DEBUG, "Loopback setupStream: direction=%s, buffer length %zu, %zu buffers",
+        direction == SOAPY_SDR_RX ? "RX" : "TX", localBufferLength, localNumBuffers);
+
+    if (direction == SOAPY_SDR_RX)
     {
-        try
+        // RX stream setup: allocate RX buffers
+        if (_buffs.empty())
         {
-            int asyncBuffs_in = std::stoi(args.at("asyncBuffs"));
-            if (asyncBuffs_in > 0)
+            bufferLength = localBufferLength;
+            numBuffers = localNumBuffers;
+
+            asyncBuffs = 0;
+            if (args.count("asyncBuffs") != 0)
             {
-                asyncBuffs = asyncBuffs_in;
+                try
+                {
+                    int asyncBuffs_in = std::stoi(args.at("asyncBuffs"));
+                    if (asyncBuffs_in > 0)
+                    {
+                        asyncBuffs = asyncBuffs_in;
+                    }
+                }
+                catch (const std::invalid_argument &){}
             }
+
+            // Initialize RX fifo
+            _buf_tail = 0;
+            _buf_count = 0;
+            _buf_head = 0;
+
+            // Allocate RX buffers
+            _buffs.resize(numBuffers);
+            for (auto &buff : _buffs) buff.data.reserve(bufferLength);
+            for (auto &buff : _buffs) buff.data.resize(bufferLength);
+
+            SoapySDR_logf(SOAPY_SDR_DEBUG, "Loopback: RX buffers allocated (%zu buffers, %zu bytes each)", numBuffers, bufferLength);
         }
-        catch (const std::invalid_argument &){}
+
+        _rxStreamSetup = true;
+        return kRxStream;
     }
-    //if (tunerType == RTLSDR_TUNER_E4000) {
-    //    IFGain[0] = 6;
-    //    IFGain[1] = 9;
-    //    IFGain[2] = 3;
-    //    IFGain[3] = 2;
-    //    IFGain[4] = 3;
-    //    IFGain[5] = 3;
-    //} else {
-    //    for (int i = 0; i < 6; i++) {
-    //        IFGain[i] = 0;
-    //    }
-    //}
-    //tunerGain = rtlsdr_get_tuner_gain(dev) / 10.0;
+    else
+    {
+        // TX stream setup: allocate loopback buffers and enable loopback
+        if (_loopback_buffs.empty())
+        {
+            _txBufferLength = localBufferLength * 4;
+            _txNumBuffers = localNumBuffers;
 
-    //clear async fifo counts
-    _buf_tail = 0;
-    _buf_count = 0;
-    _buf_head = 0;
+            // Initialize loopback ring buffer (TX -> RX path)
+            _loopback_head = 0;
+            _loopback_tail = 0;
+            _loopback_count = 0;
+            _loopback_overflow = false;
 
-    //allocate buffers
-    _buffs.resize(numBuffers);
-    for (auto &buff : _buffs) buff.data.reserve(bufferLength);
-    for (auto &buff : _buffs) buff.data.resize(bufferLength);
+            // Allocate loopback buffers
+            _loopback_buffs.resize(_txNumBuffers);
+            for (auto &buff : _loopback_buffs) buff.data.reserve(_txBufferLength);
+            for (auto &buff : _loopback_buffs) buff.data.resize(_txBufferLength);
 
-    return (SoapySDR::Stream *) this;
+            SoapySDR_logf(SOAPY_SDR_DEBUG, "Loopback: TX loopback buffers allocated (%zu buffers, %zu bytes each)", _txNumBuffers, _txBufferLength);
+        }
+
+        _loopbackEnabled = true;
+        _txStreamSetup = true;
+        return kTxStream;
+    }
 }
 
 void SoapyLoopback::closeStream(SoapySDR::Stream *stream)
 {
     this->deactivateStream(stream, 0, 0);
-    _buffs.clear();
+
+    if (stream == kRxStream)
+    {
+        _buffs.clear();
+        _rxStreamSetup = false;
+    }
+    else if (stream == kTxStream)
+    {
+        _loopback_buffs.clear();
+        _loopback_head = 0;
+        _loopback_tail = 0;
+        _loopback_count = 0;
+        _loopback_overflow = false;
+        _loopbackEnabled = false;
+        _txStreamSetup = false;
+    }
 }
 
 size_t SoapyLoopback::getStreamMTU(SoapySDR::Stream *stream) const
 {
-    return bufferLength / BYTES_PER_SAMPLE;
+    const size_t bps = _loopbackBytesPerSample > 0 ? _loopbackBytesPerSample : BYTES_PER_SAMPLE;
+    return bufferLength / bps;
 }
 
 int SoapyLoopback::activateStream(
@@ -262,13 +324,25 @@ int SoapyLoopback::activateStream(
         const size_t numElems)
 {
     if (flags != 0) return SOAPY_SDR_NOT_SUPPORTED;
-    resetBuffer = true;
-    bufferedElems = 0;
 
-    //start the async thread
-    if (not _rx_async_thread.joinable())
+    if (stream == kRxStream)
     {
-        _rx_async_thread = std::thread(&SoapyLoopback::rx_async_operation, this);
+        // RX activation
+        resetBuffer = true;
+        bufferedElems = 0;
+
+        // Start the async thread only when loopback is NOT enabled
+        // (async thread provides synthetic data for RX-only usage)
+        if (not _loopbackEnabled and not _rx_async_thread.joinable())
+        {
+            _rx_async_thread = std::thread(&SoapyLoopback::rx_async_operation, this);
+        }
+    }
+    else if (stream == kTxStream)
+    {
+        // TX activation
+        _txActive = true;
+        _loopbackEnabled = true;
     }
 
     return 0;
@@ -277,10 +351,22 @@ int SoapyLoopback::activateStream(
 int SoapyLoopback::deactivateStream(SoapySDR::Stream *stream, const int flags, const long long timeNs)
 {
     if (flags != 0) return SOAPY_SDR_NOT_SUPPORTED;
-    if (_rx_async_thread.joinable())
+
+    if (stream == kRxStream)
     {
-        _rx_async_thread.join();
+        // Deactivate RX: join the async thread if running
+        if (_rx_async_thread.joinable())
+        {
+            _rx_async_thread.join();
+        }
     }
+    else if (stream == kTxStream)
+    {
+        // Deactivate TX: signal any waiting readers
+        _txActive = false;
+        _loopback_cond.notify_all();
+    }
+
     return 0;
 }
 
@@ -319,9 +405,16 @@ int SoapyLoopback::readStream(
 
     size_t returnedElems = std::min(bufferedElems, numElems);
 
+    // Determine bytes per sample based on loopback mode
+    // In loopback mode use the stored format, otherwise CS8 (2 bytes) for synthetic data
+    const size_t bytesPerSample = _loopbackEnabled ? _loopbackBytesPerSample : BYTES_PER_SAMPLE;
+
+    // Copy data to user's buffer
+    std::memcpy(buff0, _currentBuff, returnedElems * bytesPerSample);
+
     //bump variables for next call into readStream
     bufferedElems -= returnedElems;
-    _currentBuff += returnedElems*BYTES_PER_SAMPLE;
+    _currentBuff += returnedElems * bytesPerSample;
     bufTicks += returnedElems; //for the next call to readStream if there is a remainder
 
     //return number of elements written to buff0
@@ -353,6 +446,44 @@ int SoapyLoopback::acquireReadBuffer(
     long long &timeNs,
     const long timeoutUs)
 {
+    // When loopback is enabled, read from the loopback buffer (TX -> RX)
+    if (_loopbackEnabled)
+    {
+        // Handle loopback overflow
+        if (_loopback_overflow)
+        {
+            _loopback_head = (_loopback_head + _loopback_count.exchange(0)) % _txNumBuffers;
+            _loopback_overflow = false;
+            SoapySDR::log(SOAPY_SDR_SSI, "O");
+            return SOAPY_SDR_OVERFLOW;
+        }
+
+        // Wait for loopback data if none available
+        if (_loopback_count == 0)
+        {
+            std::unique_lock<std::mutex> lock(_loopback_mutex);
+            _loopback_cond.wait_for(lock, std::chrono::microseconds(timeoutUs),
+                [this]{ return _loopback_count != 0; });
+            if (_loopback_count == 0) return SOAPY_SDR_TIMEOUT;
+        }
+
+        // Extract from loopback buffer
+        handle = _loopback_head;
+        _loopback_head = (_loopback_head + 1) % _txNumBuffers;
+
+        auto &lbuff = _loopback_buffs[handle];
+        bufTicks = lbuff.tick;
+        timeNs = SoapySDR::ticksToTimeNs(lbuff.tick, sampleRate);
+        buffs[0] = (void *)lbuff.data.data();
+        flags = SOAPY_SDR_HAS_TIME;
+
+        // Use stored bytes per sample for the loopback format
+        size_t numElems = lbuff.data.size() / _loopbackBytesPerSample;
+        _loopback_count--;
+        return numElems;
+    }
+
+    // Original behavior: read from synthetic RX buffer
     //reset is issued by various settings
     //to drain old data out of the queue
     if (resetBuffer)
@@ -397,6 +528,73 @@ void SoapyLoopback::releaseReadBuffer(
     SoapySDR::Stream *stream,
     const size_t handle)
 {
+    // In loopback mode, _loopback_count is already decremented in acquireReadBuffer
+    // so we don't need to do anything here
+    if (_loopbackEnabled)
+    {
+        return;
+    }
+
     //TODO this wont handle out of order releases
     _buf_count--;
+}
+
+/*******************************************************************
+ * TX Stream API - writeStream
+ ******************************************************************/
+
+int SoapyLoopback::writeStream(
+        SoapySDR::Stream *stream,
+        const void * const *buffs,
+        const size_t numElems,
+        int &flags,
+        const long long timeNs,
+        const long timeoutUs)
+{
+    if (!_txActive)
+    {
+        SoapySDR_log(SOAPY_SDR_ERROR, "writeStream: TX not active");
+        return SOAPY_SDR_STREAM_ERROR;
+    }
+
+    if (buffs == nullptr || buffs[0] == nullptr)
+    {
+        SoapySDR_log(SOAPY_SDR_ERROR, "writeStream: null buffer pointer");
+        return SOAPY_SDR_STREAM_ERROR;
+    }
+
+    // Use the stored bytes per sample for the loopback format
+    const size_t numBytes = numElems * _loopbackBytesPerSample;
+
+    // Get input buffer
+    const char *input = (const char *)buffs[0];
+
+    // Check for overflow condition
+    if (_loopback_count >= _txNumBuffers)
+    {
+        _loopback_overflow = true;
+        SoapySDR::log(SOAPY_SDR_SSI, "U");  // Underflow on TX side means overflow on loopback
+        return SOAPY_SDR_OVERFLOW;
+    }
+
+    // Get the current tick for timestamps
+    unsigned long long tick = ticks.fetch_add(numElems);
+
+    // Copy data into loopback ring buffer
+    {
+        std::lock_guard<std::mutex> lock(_loopback_mutex);
+
+        auto &buff = _loopback_buffs[_loopback_tail];
+        buff.tick = tick;
+        buff.data.resize(numBytes);
+        std::memcpy(buff.data.data(), input, numBytes);
+
+        // Increment tail pointer
+        _loopback_tail = (_loopback_tail + 1) % _txNumBuffers;
+        _loopback_count++;
+    }
+
+    // Notify any waiting readers
+    _loopback_cond.notify_one();
+    return numElems;
 }

--- a/test/test_loopback.cpp
+++ b/test/test_loopback.cpp
@@ -1,0 +1,335 @@
+/*
+ * Standalone test suite for SoapyLoopback TX->RX loopback path.
+ * Raw main() + assert, no external test framework.
+ *
+ * Build: cmake --build build --target test_loopback
+ * Run:   ctest --test-dir build --output-on-failure --timeout 30
+ */
+
+#include <SoapySDR/Device.hpp>
+#include <SoapySDR/Modules.hpp>
+#include <SoapySDR/Formats.h>
+#include <SoapySDR/Errors.hpp>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+// --- Helpers ---
+
+#define TEST_BEGIN(name) std::fprintf(stderr, "TEST: %s ... ", name)
+#define TEST_PASS()      std::fprintf(stderr, "PASS\n")
+
+// assert() may be compiled out under NDEBUG; use this to keep checks active
+#define CHECK(expr) do { if (!(expr)) { \
+    std::fprintf(stderr, "FAIL: %s at %s:%d\n", #expr, __FILE__, __LINE__); \
+    std::abort(); } } while(0)
+
+static SoapySDR::Device *openDevice()
+{
+    SoapySDR::KwargsList results = SoapySDR::Device::enumerate("driver=loopback");
+    CHECK(!results.empty());
+    SoapySDR::Device *dev = SoapySDR::Device::make(results.at(0));
+    CHECK(dev != nullptr);
+    return dev;
+}
+
+static void closeDevice(SoapySDR::Device *dev)
+{
+    SoapySDR::Device::unmake(dev);
+}
+
+// --- Test cases ---
+
+static void test_module_load()
+{
+    TEST_BEGIN("module_load");
+    std::string err = SoapySDR::loadModule(SOAPY_LOOPBACK_MODULE_PATH);
+    CHECK(err.empty());
+    TEST_PASS();
+}
+
+static void test_device_enumeration()
+{
+    TEST_BEGIN("device_enumeration");
+    SoapySDR::KwargsList results = SoapySDR::Device::enumerate("driver=loopback");
+    CHECK(results.size() >= 1);
+    TEST_PASS();
+}
+
+static void test_tx_stream_setup_teardown()
+{
+    TEST_BEGIN("tx_stream_setup_teardown");
+    SoapySDR::Device *dev = openDevice();
+
+    SoapySDR::Stream *txStream = dev->setupStream(SOAPY_SDR_TX, SOAPY_SDR_CF32);
+    CHECK(txStream != nullptr);
+    dev->closeStream(txStream);
+
+    closeDevice(dev);
+    TEST_PASS();
+}
+
+static void test_tx_rx_cf32_data_integrity()
+{
+    TEST_BEGIN("tx_rx_cf32_data_integrity");
+    SoapySDR::Device *dev = openDevice();
+
+    // TX must be set up first to enable loopback
+    SoapySDR::Stream *txStream = dev->setupStream(SOAPY_SDR_TX, SOAPY_SDR_CF32);
+    SoapySDR::Stream *rxStream = dev->setupStream(SOAPY_SDR_RX, SOAPY_SDR_CF32);
+    CHECK(txStream != nullptr);
+    CHECK(rxStream != nullptr);
+
+    dev->activateStream(txStream);
+    dev->activateStream(rxStream);
+
+    const size_t N = 1024;
+    // Pattern: {i, N-i} as float pairs
+    std::vector<float> txBuf(N * 2);
+    for (size_t i = 0; i < N; i++)
+    {
+        txBuf[i * 2 + 0] = static_cast<float>(i);
+        txBuf[i * 2 + 1] = static_cast<float>(N - i);
+    }
+
+    int flags = 0;
+    long long timeNs = 0;
+    const void *txBuffs[] = { txBuf.data() };
+    CHECK(dev->writeStream(txStream, txBuffs, N, flags, timeNs) == static_cast<int>(N));
+
+    // Read back
+    std::vector<float> rxBuf(N * 2, 0.0f);
+    void *rxBuffs[] = { rxBuf.data() };
+    flags = 0;
+    timeNs = 0;
+    CHECK(dev->readStream(rxStream, rxBuffs, N, flags, timeNs) == static_cast<int>(N));
+
+    // Verify byte-exact match
+    CHECK(std::memcmp(txBuf.data(), rxBuf.data(), N * sizeof(float) * 2) == 0);
+
+    dev->deactivateStream(txStream);
+    dev->deactivateStream(rxStream);
+    dev->closeStream(txStream);
+    dev->closeStream(rxStream);
+    closeDevice(dev);
+    TEST_PASS();
+}
+
+static void test_tx_rx_cs16_data_integrity()
+{
+    TEST_BEGIN("tx_rx_cs16_data_integrity");
+    SoapySDR::Device *dev = openDevice();
+
+    SoapySDR::Stream *txStream = dev->setupStream(SOAPY_SDR_TX, SOAPY_SDR_CS16);
+    SoapySDR::Stream *rxStream = dev->setupStream(SOAPY_SDR_RX, SOAPY_SDR_CS16);
+    CHECK(txStream != nullptr);
+    CHECK(rxStream != nullptr);
+
+    dev->activateStream(txStream);
+    dev->activateStream(rxStream);
+
+    const size_t N = 1024;
+    // Pattern: {i, N-i} as int16_t pairs (4 bytes/sample)
+    std::vector<int16_t> txBuf(N * 2);
+    for (size_t i = 0; i < N; i++)
+    {
+        txBuf[i * 2 + 0] = static_cast<int16_t>(i);
+        txBuf[i * 2 + 1] = static_cast<int16_t>(N - i);
+    }
+
+    int flags = 0;
+    long long timeNs = 0;
+    const void *txBuffs[] = { txBuf.data() };
+    CHECK(dev->writeStream(txStream, txBuffs, N, flags, timeNs) == static_cast<int>(N));
+
+    // Read back
+    std::vector<int16_t> rxBuf(N * 2, 0);
+    void *rxBuffs[] = { rxBuf.data() };
+    flags = 0;
+    timeNs = 0;
+    CHECK(dev->readStream(rxStream, rxBuffs, N, flags, timeNs) == static_cast<int>(N));
+
+    // Verify byte-exact match
+    CHECK(std::memcmp(txBuf.data(), rxBuf.data(), N * sizeof(int16_t) * 2) == 0);
+
+    dev->deactivateStream(txStream);
+    dev->deactivateStream(rxStream);
+    dev->closeStream(txStream);
+    dev->closeStream(rxStream);
+    closeDevice(dev);
+    TEST_PASS();
+}
+
+static void test_rx_has_time_flag()
+{
+    TEST_BEGIN("rx_has_time_flag");
+    SoapySDR::Device *dev = openDevice();
+
+    SoapySDR::Stream *txStream = dev->setupStream(SOAPY_SDR_TX, SOAPY_SDR_CF32);
+    SoapySDR::Stream *rxStream = dev->setupStream(SOAPY_SDR_RX, SOAPY_SDR_CF32);
+    dev->activateStream(txStream);
+    dev->activateStream(rxStream);
+
+    const size_t N = 512;
+    std::vector<float> txBuf(N * 2, 1.0f);
+
+    int flags = 0;
+    long long timeNs = 0;
+    const void *txBuffs[] = { txBuf.data() };
+    CHECK(dev->writeStream(txStream, txBuffs, N, flags, timeNs) == static_cast<int>(N));
+
+    std::vector<float> rxBuf(N * 2, 0.0f);
+    void *rxBuffs[] = { rxBuf.data() };
+    flags = 0;
+    timeNs = 0;
+    CHECK(dev->readStream(rxStream, rxBuffs, N, flags, timeNs) == static_cast<int>(N));
+
+    // Verify SOAPY_SDR_HAS_TIME flag is set
+    CHECK(flags & SOAPY_SDR_HAS_TIME);
+
+    dev->deactivateStream(txStream);
+    dev->deactivateStream(rxStream);
+    dev->closeStream(txStream);
+    dev->closeStream(rxStream);
+    closeDevice(dev);
+    TEST_PASS();
+}
+
+static void test_overflow_on_full_ring_buffer()
+{
+    TEST_BEGIN("overflow_on_full_ring_buffer");
+    SoapySDR::Device *dev = openDevice();
+
+    SoapySDR::Stream *txStream = dev->setupStream(SOAPY_SDR_TX, SOAPY_SDR_CF32);
+    SoapySDR::Stream *rxStream = dev->setupStream(SOAPY_SDR_RX, SOAPY_SDR_CF32);
+    dev->activateStream(txStream);
+    dev->activateStream(rxStream);
+
+    const size_t N = 1024;
+    std::vector<float> txBuf(N * 2, 0.5f);
+    const void *txBuffs[] = { txBuf.data() };
+
+    // Write 20 times without reading to fill the ring buffer (> DEFAULT_NUM_BUFFERS=15)
+    bool gotOverflow = false;
+    for (int i = 0; i < 20; i++)
+    {
+        int flags = 0;
+        long long timeNs = 0;
+        if (dev->writeStream(txStream, txBuffs, N, flags, timeNs) == SOAPY_SDR_OVERFLOW)
+        {
+            gotOverflow = true;
+            break;
+        }
+    }
+    CHECK(gotOverflow);
+
+    dev->deactivateStream(txStream);
+    dev->deactivateStream(rxStream);
+    dev->closeStream(txStream);
+    dev->closeStream(rxStream);
+    closeDevice(dev);
+    TEST_PASS();
+}
+
+static void test_multiple_write_read_cycles()
+{
+    TEST_BEGIN("multiple_write_read_cycles");
+    SoapySDR::Device *dev = openDevice();
+
+    SoapySDR::Stream *txStream = dev->setupStream(SOAPY_SDR_TX, SOAPY_SDR_CF32);
+    SoapySDR::Stream *rxStream = dev->setupStream(SOAPY_SDR_RX, SOAPY_SDR_CF32);
+    dev->activateStream(txStream);
+    dev->activateStream(rxStream);
+
+    const size_t N = 512;
+
+    for (int cycle = 0; cycle < 5; cycle++)
+    {
+        // Unique pattern per cycle
+        std::vector<float> txBuf(N * 2);
+        for (size_t i = 0; i < N; i++)
+        {
+            txBuf[i * 2 + 0] = static_cast<float>(cycle * 1000 + i);
+            txBuf[i * 2 + 1] = static_cast<float>(cycle * 1000 + N - i);
+        }
+
+        int flags = 0;
+        long long timeNs = 0;
+        const void *txBuffs[] = { txBuf.data() };
+        CHECK(dev->writeStream(txStream, txBuffs, N, flags, timeNs) == static_cast<int>(N));
+
+        std::vector<float> rxBuf(N * 2, 0.0f);
+        void *rxBuffs[] = { rxBuf.data() };
+        flags = 0;
+        timeNs = 0;
+        CHECK(dev->readStream(rxStream, rxBuffs, N, flags, timeNs) == static_cast<int>(N));
+
+        CHECK(std::memcmp(txBuf.data(), rxBuf.data(), N * sizeof(float) * 2) == 0);
+    }
+
+    dev->deactivateStream(txStream);
+    dev->deactivateStream(rxStream);
+    dev->closeStream(txStream);
+    dev->closeStream(rxStream);
+    closeDevice(dev);
+    TEST_PASS();
+}
+
+static void test_stream_mtu()
+{
+    TEST_BEGIN("stream_mtu");
+    SoapySDR::Device *dev = openDevice();
+
+    SoapySDR::Stream *txStream = dev->setupStream(SOAPY_SDR_TX, SOAPY_SDR_CF32);
+    CHECK(dev->getStreamMTU(txStream) > 0);
+
+    dev->closeStream(txStream);
+    closeDevice(dev);
+    TEST_PASS();
+}
+
+static void test_full_duplex_flag()
+{
+    TEST_BEGIN("full_duplex_flag");
+    SoapySDR::Device *dev = openDevice();
+
+    CHECK(dev->getFullDuplex(SOAPY_SDR_TX, 0));
+    CHECK(dev->getFullDuplex(SOAPY_SDR_RX, 0));
+
+    closeDevice(dev);
+    TEST_PASS();
+}
+
+static void test_module_unload()
+{
+    TEST_BEGIN("module_unload");
+    std::string err = SoapySDR::unloadModule(SOAPY_LOOPBACK_MODULE_PATH);
+    CHECK(err.empty());
+    TEST_PASS();
+}
+
+// --- Main ---
+
+int main()
+{
+    std::fprintf(stderr, "=== SoapyLoopback Test Suite ===\n");
+
+    test_module_load();
+    test_device_enumeration();
+    test_tx_stream_setup_teardown();
+    test_tx_rx_cf32_data_integrity();
+    test_tx_rx_cs16_data_integrity();
+    test_rx_has_time_flag();
+    test_overflow_on_full_ring_buffer();
+    test_multiple_write_read_cycles();
+    test_stream_mtu();
+    test_full_duplex_flag();
+    test_module_unload();
+
+    std::fprintf(stderr, "=== All tests passed ===\n");
+    return 0;
+}


### PR DESCRIPTION
Adds full TX (transmit) support to the loopback driver, plus a standalone test suite that exercises the TX→RX path without any external dependencies.

## Changes

### TX implementation (`bffb122`)

- `writeStream`: copies TX samples into a shared ring buffer (default 15 buffers × DEFAULT_BUFFER_LENGTH samples)
- `acquireReadBuffer`: reads from the loopback ring buffer when TX is active, instead of generating synthetic data
- Multi-format support: CS8 (2 B/sample), CS12 (3), CS16 (4), CF32 (8) — format is negotiated at `setupStream` time
- Overflow detection: `writeStream` returns `SOAPY_SDR_OVERFLOW` when the ring buffer is full
- `getFullDuplex` returns `true` for both directions
- Timestamp propagation: RX reads carry `SOAPY_SDR_HAS_TIME`
- Thread-safe: mutex + condvar synchronisation on the loopback buffer

### Standalone test suite (`eab0395`)

`test/test_loopback.cpp` — 11 test cases, no external framework:

1. Module load/unload
2. Device enumeration (`driver=loopback`)
3. TX stream setup/teardown
4. TX→RX CF32 data integrity (1024 samples, bit-exact)
5. TX→RX CS16 data integrity (1024 samples, bit-exact)
6. RX `SOAPY_SDR_HAS_TIME` flag present after loopback read
7. Ring buffer overflow → `SOAPY_SDR_OVERFLOW` return
8. Multiple write/read cycles (5 × 512 samples, unique patterns)
9. `getStreamMTU` returns nonzero value
10. `getFullDuplex` returns true for TX and RX
11. Module unload

`CMakeLists.txt`: adds `enable_testing()` + `test_loopback` CTest target (30 s timeout, no install required — loads module via `$<TARGET_FILE:soapyloopback>`).

## Supersedes

Supersedes #3 — incorporates the same TX implementation with the addition of multi-format support and a test suite.

## Tested

macOS ARM64 (Apple Silicon), SoapySDR 0.8, Clang 22 — all 11 tests pass.